### PR TITLE
Remove NotLikeOp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - GO111MODULE=on
 script:
   - GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+  - GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
   - make
   - make lint
   - make test

--- a/Makefile
+++ b/Makefile
@@ -83,16 +83,7 @@ clean:
 
 .PHONY: test
 test:
-	go test ./cmd/tsl_parser
-	go test ./cmd/tsl_sqlite
-	go test ./cmd/tsl_gorm
-	go test ./cmd/tsl_mongo
-	go test ./cmd/tsl_graphql
-	go test ./cmd/tsl_mem
-	go test ./pkg/tsl
-	go test ./pkg/walkers/sql
-	go test ./pkg/walkers/mongo
-	go test ./pkg/walkers/graphviz
+	ginkgo -r ./cmd ./pkg
 
 .PHONY: generate
 generate:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/lib/pq v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0
+	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/gomega v1.7.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect

--- a/pkg/tsl/consts.go
+++ b/pkg/tsl/consts.go
@@ -32,7 +32,6 @@ const (
 	NotRegexOp   = "$nregex"
 	LikeOp       = "$like"
 	ILikeOp      = "$ilike"
-	NotLikeOp    = "$nlike"
 	InOp         = "$in"
 	NotInOp      = "$nin"
 	BetweenOp    = "$between"

--- a/pkg/tsl/tsl_test.go
+++ b/pkg/tsl/tsl_test.go
@@ -138,6 +138,7 @@ func TestLikeOp(t *testing.T) {
 		t.Fail()
 	}
 }
+
 func TestILikeOp(t *testing.T) {
 	// Test valid string.
 	input := "a ilike 'my%'"
@@ -151,6 +152,52 @@ func TestILikeOp(t *testing.T) {
 	// Test json output.
 	expected := `
 		{"func":"$ilike","left":{"func":"$ident","left":"a"},"right":{"func":"$string","left":"my%"}}
+	`
+	expected = removeWhitespace(expected)
+	s, _ := json.Marshal(n)
+	if string(s) != expected {
+		t.Fatalf("expected %s instead it was %s", expected, string(s))
+		t.Fail()
+	}
+}
+
+func TestNotLikeOp(t *testing.T) {
+	// Test valid string.
+	input := "a not like 'my%'"
+
+	// Test TSL parser.
+	n, err := parseTSL(input)
+	if err != nil {
+		t.Fail()
+	}
+
+	// Test json output.
+	expected := `
+		{"func":"$not","left":{"func":"$like","left":{"func":"$ident","left":"a"},
+		"right":{"func":"$string","left":"my%"}}}
+	`
+	expected = removeWhitespace(expected)
+	s, _ := json.Marshal(n)
+	if string(s) != expected {
+		t.Fatalf("expected %s instead it was %s", expected, string(s))
+		t.Fail()
+	}
+}
+
+func TestNotILikeOp(t *testing.T) {
+	// Test valid string.
+	input := "a not ilike 'my%'"
+
+	// Test TSL parser.
+	n, err := parseTSL(input)
+	if err != nil {
+		t.Fail()
+	}
+
+	// Test json output.
+	expected := `
+		{"func":"$not","left":{"func":"$ilike","left":{"func":"$ident","left":"a"},
+		"right":{"func":"$string","left":"my%"}}}
 	`
 	expected = removeWhitespace(expected)
 	s, _ := json.Marshal(n)

--- a/pkg/walkers/semantics/walk_test.go
+++ b/pkg/walkers/semantics/walk_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Yaacov Zamir <kobi.zamir@gmail.com>
+// and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semantics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/yaacov/tree-search-language/pkg/tsl"
+)
+
+func TestWalk(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Walk")
+}
+
+var _ = Describe("Walk", func() {
+	// This is the record that we will use for all the tests:
+	record := map[string]interface{}{
+		"title":       "A good book",
+		"author":      "Joe",
+		"spec.pages":  14,
+		"spec.rating": 5,
+	}
+
+	// This is the evaluation function that we will use to extract fields from the record:
+	eval := func(name string) (value interface{}, ok bool) {
+		value, ok = record[name]
+		return
+	}
+
+	DescribeTable("Returns the expected result",
+		func(text string, expected bool) {
+			// Parse the text:
+			tree, err := tsl.ParseTSL(text)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get the value:
+			actual, err := Walk(tree, eval)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+
+		// NOT combined with LIKE and ILIKE:
+		Entry("like good", "title like '%good%'", true),
+		Entry("like bad", "title like '%bad%'", false),
+		Entry("ilike GOOD", "title ilike '%GOOD%'", true),
+		Entry("ilike BAD", "title ilike '%BAD%'", false),
+		Entry("not like good", "title not like '%good%'", false),
+		Entry("not like bad", "title not like '%bad%'", true),
+		Entry("not ilike GOOD", "title not ilike '%GOOD%'", false),
+		Entry("not ilike BAD", "title not ilike '%BAD%'", true),
+	)
+})

--- a/pkg/walkers/sql/walk.go
+++ b/pkg/walkers/sql/walk.go
@@ -142,9 +142,6 @@ func unaryStep(n tsl.Node) (s sq.Sqlizer, err error) {
 	case tsl.ILikeOp:
 		t := fmt.Sprintf("%s ILIKE ?", sql)
 		s = sq.Expr(t, right[0])
-	case tsl.NotLikeOp:
-		t := fmt.Sprintf("%s NOT LIKE ?", sql)
-		s = sq.Expr(t, right[0])
 	case tsl.BetweenOp:
 		t := fmt.Sprintf("%s BETWEEN ? AND ?", sql)
 		s = sq.Expr(t, right[0], right[1])
@@ -186,7 +183,7 @@ func Walk(n tsl.Node) (s sq.Sqlizer, err error) {
 	case tsl.NotOp, tsl.EqOp, tsl.NotEqOp, tsl.LtOp, tsl.LteOp, tsl.GtOp, tsl.GteOp,
 		tsl.InOp, tsl.NotInOp, tsl.IsNilOp, tsl.IsNotNilOp:
 		return unaryStep(n)
-	case tsl.LikeOp, tsl.ILikeOp, tsl.NotLikeOp, tsl.BetweenOp, tsl.NotBetweenOp:
+	case tsl.LikeOp, tsl.ILikeOp, tsl.BetweenOp, tsl.NotBetweenOp:
 		return unaryStep(n)
 	default:
 		// If here than the operator is not supported.


### PR DESCRIPTION
This patch removes the `NotLikeOp` operation because that is now
implemented by the parser as a combination of `Not` and `Like`.

Fixes: https://github.com/yaacov/tree-search-language/issues/12