### PR TITLE
Support has-many relation on string field

### DIFF
--- a/v5/go.mod
+++ b/v5/go.mod
@@ -1,7 +1,6 @@
 module github.com/yaacov/tree-search-language/v5
 
 require (
-	cloud.google.com/go v0.37.4 // indirect
 	github.com/Masterminds/squirrel v1.4.0
 	github.com/antlr/antlr4 v0.0.0-20200712162734-eb1adaa8a7a6
 	github.com/fatih/color v1.9.0 // indirect
@@ -12,13 +11,10 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.5
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sys v0.0.0-20200724161237-0e2f3a69832c // indirect
-	golang.org/x/text v0.3.3 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
 


### PR DESCRIPTION
This is my case:
- `Subscriptions` has many `ReservedResource`
- `ReservedResource` has string field `ResourceName`
I need to support the following SQL in `semantics.Walk`:
```sql
Subscription.Managed = 'true' and Subscription.Status not in ('Deprovisioned','Deleted') and ReservedResource.ResourceName in ('resource1', 'resource2')
```
`has many` will replace `ReservedResource.ResourceName` with an array of values, so the existing implementation doesn't work.

While this PR solves `my` problem, I'm open for generalizations (to some extension... :)