### PR TITLE
add mutex to make parser safe for concurrent use

### DIFF
--- a/v6/pkg/parser/parse.go
+++ b/v6/pkg/parser/parse.go
@@ -1,5 +1,9 @@
 package parser
 
+import "sync"
+
+var parseMutex sync.Mutex
+
 // tslLexer adapts our Lexer to the goyacc interface
 type tslLexer struct {
 	lexer *Lexer
@@ -30,8 +34,12 @@ func (l *tslLexer) Error(s string) {
 	}
 }
 
-// Parse parses a TSL expression and returns the AST
+// Parse parses a TSL expression and returns the AST.
+// It is safe for concurrent use.
 func Parse(input string) (*Node, error) {
+	parseMutex.Lock()
+	defer parseMutex.Unlock()
+
 	// Reset global state
 	parseResult = nil
 	parseError = nil

--- a/v6/pkg/parser/parse_test.go
+++ b/v6/pkg/parser/parse_test.go
@@ -1,0 +1,47 @@
+package parser
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestParseConcurrent(t *testing.T) {
+	expressions := []string{
+		"name = 'alice'",
+		"age > 25 and city = 'rome'",
+		"status in ['active', 'pending']",
+		"price between 10 and 100",
+		"not (deleted = true)",
+		"title like '%book%'",
+		"created_at > 2023-01-01",
+		"(a = 1 or b = 2) and c = 3",
+	}
+
+	var wg sync.WaitGroup
+	errors := make(chan error, len(expressions)*10)
+
+	for i := 0; i < 10; i++ {
+		for _, expr := range expressions {
+			wg.Add(1)
+			go func(input string) {
+				defer wg.Done()
+				node, err := Parse(input)
+				if err != nil {
+					errors <- err
+					return
+				}
+				if node == nil {
+					errors <- fmt.Errorf("got nil node for input: %s", input)
+				}
+			}(expr)
+		}
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent parse failed: %v", err)
+	}
+}


### PR DESCRIPTION
The parser uses global variables (parseResult, parseError, currentLexer) that are shared across calls. Without synchronization, concurrent calls to Parse() corrupt each other's state. Add a sync.Mutex to serialize access, and a concurrent test with the race detector to verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser reliability when multiple parsing operations run concurrently.
  * Prevented inconsistent or missing parsing results under concurrent usage.

* **Tests**
  * Added coverage for repeated concurrent parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->