### PR TITLE
use typed Books slice and deterministic graphviz node IDs

### DIFF
--- a/v6/cmd/model/model.go
+++ b/v6/cmd/model/model.go
@@ -31,7 +31,7 @@ type Book struct {
 }
 
 // Books are the demo list of books.
-var Books = []interface{}{
+var Books = []Book{
 	Book{Title: "Book", Author: "Joe", Spec: BookSpecs{Pages: 100, Rating: 4}, OnLoan: true},
 	Book{Title: "Other Book", Author: "Jane", Spec: BookSpecs{Pages: 200, Rating: 3}, OnLoan: true},
 	Book{Title: "Some Book", Author: "Jane", Spec: BookSpecs{Pages: 50, Rating: 5}, OnLoan: true},

--- a/v6/cmd/tsl_mem/model.go
+++ b/v6/cmd/tsl_mem/model.go
@@ -75,17 +75,17 @@ func prepareCollection() (err error) {
 	for _, b := range model.Books {
 		// Create a new book.
 		newBook := Book{
-			"title":  b.(model.Book).Title,
-			"author": b.(model.Book).Author,
-			"onloan": b.(model.Book).OnLoan,
+			"title":  b.Title,
+			"author": b.Author,
+			"onloan": b.OnLoan,
 		}
 
 		// Add optional parameters.
-		if b.(model.Book).Spec.Pages > 0 {
-			newBook["spec.pages"] = b.(model.Book).Spec.Pages
+		if b.Spec.Pages > 0 {
+			newBook["spec.pages"] = b.Spec.Pages
 		}
-		if b.(model.Book).Spec.Rating > 0 {
-			newBook["spec.rating"] = b.(model.Book).Spec.Rating
+		if b.Spec.Rating > 0 {
+			newBook["spec.rating"] = b.Spec.Rating
 		}
 
 		// Insert new book to the books array.

--- a/v6/pkg/walkers/graphviz/walk.go
+++ b/v6/pkg/walkers/graphviz/walk.go
@@ -18,8 +18,8 @@ package graphviz
 
 import (
 	"fmt"
-	"math/rand"
 	"strings"
+	"sync/atomic"
 
 	"github.com/yaacov/tree-search-language/v6/pkg/tsl"
 )
@@ -38,14 +38,11 @@ const timestampStyle = baseRecordStyle + " color=orange"
 const opStyle = baseBoxStyle + " color=black"
 const arrayStyle = baseBoxStyle + " color=green"
 
-// Generate a random string of specified length using only letters
-func randStr(l int) string {
-	const pool = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	bytes := make([]byte, l)
-	for i := 0; i < l; i++ {
-		bytes[i] = pool[rand.Intn(len(pool))]
-	}
-	return string(bytes)
+var nodeCounter atomic.Uint64
+
+func nextNodeID() string {
+	n := nodeCounter.Add(1)
+	return fmt.Sprintf("n%d", n)
 }
 
 // formatLeafNodeWithInput creates a graphviz node string for leaf nodes including input string
@@ -75,7 +72,7 @@ func handleChildren(in string, children []*tsl.TSLNode) (string, []string, error
 	result := ""
 
 	for _, child := range children {
-		childID := randStr(4)
+		childID := nextNodeID()
 		childrenIDs = append(childrenIDs, childID)
 
 		r, err := Walk(in, child, childID)
@@ -96,10 +93,10 @@ func handleChildren(in string, children []*tsl.TSLNode) (string, []string, error
 //
 // The return string will be a node list for a .dot file:
 //
-//	tcuA [shape=box color=black label="$eq"]
-//	xhxK [shape=record color=red label="$ident | 'city'" ]
-//	QFDa [shape=record color=blue label="$string | 'rome'" ]
-//	tcuA -> { xhxK, QFDa }
+//	n1 [shape=box color=black label="EQ"]
+//	n2 [shape=record color=red label="IDENTIFIER | 'city'" ]
+//	n3 [shape=record color=blue label="STRING | 'rome'" ]
+//	n1 -> { n2, n3 }
 //
 // For valid Graphviz dot file, the nodes must be wrapped in a `digraph` object:
 //
@@ -107,7 +104,7 @@ func handleChildren(in string, children []*tsl.TSLNode) (string, []string, error
 //	s = fmt.Sprintf("digraph {\n%s\n}\n", s)
 func Walk(in string, n *tsl.TSLNode, nodeID string) (out string, err error) {
 	if nodeID == "" {
-		nodeID = randStr(4)
+		nodeID = nextNodeID()
 	}
 
 	switch n.Type() {


### PR DESCRIPTION
- Change model.Books from []interface{} to []Book, removing all type assertions in tsl_mem/model.go
- Replace math/rand with an atomic counter for graphviz node IDs, producing deterministic, reproducible dot output